### PR TITLE
Update docker-compose to 1.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 awscli==1.11.44
 docker==2.0.2
-docker-compose==1.10.0
+docker-compose==1.10.1
 pylint==1.6.5
 selenium==3.0.2


### PR DESCRIPTION
Update the requirement for docker-compose to 1.10.1. Released February
1, 2017.

https://github.com/docker/compose/releases/tag/1.10.1