### PR TITLE
Docker 1.13.1 Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.13.0-git
+FROM docker:1.13.1-git
 
 RUN apk add --no-cache \
       ansible \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 awscli==1.11.44
 docker==2.0.2
-docker-compose==1.10.1
+docker-compose==1.11.1
 pylint==1.6.5
 selenium==3.0.2


### PR DESCRIPTION
Update the base image to `docker:1.13.1-git`. Also update docker-compose to `1.11.1`.

https://github.com/docker/compose/releases/tag/1.11.1
https://github.com/docker/docker/releases/tag/v1.13.1