### PR TITLE
Update to docker:17.03.0-ce-git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:1.13.1-git
+FROM docker:17.03.0-ce-git
 
 RUN apk add --no-cache \
       ansible \


### PR DESCRIPTION
Update from docker:1.13.1-git to docker:17.03.0-ce-git. Start with this
version, Docker has switched to a date-based versioning scheme.