### PR TITLE
Update to Docker 17.05.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.04.0-ce-git
+FROM docker:17.05.0-ce-git
 
 RUN apk add --no-cache \
       ansible \


### PR DESCRIPTION
The 17.05.0-ce-git tag currently refers to RC1. This image can be
rebuilt as it progresses to release.