### PR TITLE
Update to Docker 17.06.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.05.0-ce-git
+FROM docker:17.06.0-ce-git
 
 RUN apk add --no-cache \
       ansible \


### PR DESCRIPTION
Update the base image tag for Docker 17.06.0. The `17.06.0-ce-git` tag current refers to RC1. This image will be automatically rebuilt as it progresses to release.